### PR TITLE
Changed keywords to an array per package.json specs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lodash-cli",
   "version": "4.17.5",
   "description": "The Lodash command-line interface.",
-  "keywords": "builder, compile, customize, lodash",
+  "keywords": ["builder, compile, customize, lodash"],
   "homepage": "https://lodash.com/custom-builds",
   "repository": "lodash/lodash-cli",
   "license": "MIT",


### PR DESCRIPTION
changed `"keywords": "builder, compile, customize, lodash"` to an array `"keywords": ["builder, compile, customize, lodash"]`