### PR TITLE
fix: update node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "closure-compiler": "0.2.12",
     "glob": "7.1.1",
-    "lodash": "4.17.5",
+    "lodash": "4.17.11",
     "semver": "5.3.0",
     "uglify-js": "2.7.5"
   },


### PR DESCRIPTION
Fix npm audit errors 

 lodash less than 4.17.11 has Prototype Pollution.  

patched in 4.17.11

 https://nodesecurity.io/advisories/782        