### PR TITLE
lodash-modularize - Import of keysIn is missing

### DIFF
--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -790,7 +790,7 @@ exports.funcDep = new Hash({
   'baseAssignValue': ['defineProperty'],
   'baseAt': ['get'],
   'baseClamp': [],
-  'baseClone': ['arrayEach', 'assignValue', 'baseAssign', 'baseAssignIn', 'cloneBuffer', 'copyArray', 'copySymbols', 'copySymbolsIn', 'getAllKeys', 'getAllKeysIn', 'getTag', 'initCloneArray', 'initCloneByTag', 'initCloneObject', 'isArray', 'isBuffer', 'isMap', 'isObject', 'isSet', 'keys', 'Stack'],
+  'baseClone': ['arrayEach', 'assignValue', 'baseAssign', 'baseAssignIn', 'cloneBuffer', 'copyArray', 'copySymbols', 'copySymbolsIn', 'getAllKeys', 'getAllKeysIn', 'getTag', 'initCloneArray', 'initCloneByTag', 'initCloneObject', 'isArray', 'isBuffer', 'isMap', 'isObject', 'isSet', 'keys', 'Stack', 'keysIn'],
   'baseConforms': ['baseConformsTo', 'keys'],
   'baseConformsTo': [],
   'baseCreate': ['isObject'],


### PR DESCRIPTION
The dependency **keysIn** is missing [here](https://github.com/lodash/lodash/blob/4.17.15-es/_baseClone.js), a hotfix is critical. The latest version has a problem that can cause strange behavior, especially in a production environment.