### PR TITLE
Add isArray as dependency of baseOrderBy

### DIFF
--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -847,7 +847,7 @@ exports.funcDep = new Hash({
   'baseMerge': ['assignMergeValue', 'baseFor', 'baseMergeDeep', 'isObject', 'keysIn', 'safeGet', 'Stack'],
   'baseMergeDeep': ['assignMergeValue', 'cloneBuffer', 'cloneTypedArray', 'copyArray', 'initCloneObject', 'isArguments', 'isArray', 'isArrayLikeObject', 'isBuffer', 'isFunction', 'isObject', 'isPlainObject', 'isTypedArray', 'safeGet', 'toPlainObject'],
   'baseNth': ['isIndex'],
-  'baseOrderBy': ['arrayMap', 'baseMap', 'baseSortBy', 'baseUnary', 'compareMultiple', 'getIteratee', 'identity'],
+  'baseOrderBy': ['arrayMap', 'baseMap', 'baseSortBy', 'baseUnary', 'compareMultiple', 'getIteratee', 'identity', 'isArray'],
   'basePick': ['basePickBy', 'hasIn'],
   'basePickBy': ['baseGet', 'baseSet', 'castPath'],
   'baseProperty': [],


### PR DESCRIPTION
This fixes `isArray is not defined` error when lodash is built with nodejs 12.x

More details here https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=965353